### PR TITLE
Add logic to Runner to hide Links unless they have all of their Flags set. Update some import logic to account for older Games which don't have Flags.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seeya",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/generator/scene/scene.service.ts
+++ b/src/app/generator/scene/scene.service.ts
@@ -9,6 +9,7 @@ import { GameModel } from '../../shared/models/game-model';
 import { SceneModel } from '../../shared/models/scene-model';
 import { LinkModel } from '../../shared/models/link-model';
 import { FlagModel } from '../../shared/models/flag-model';
+import { FlagReferenceModel } from '../../shared/models/flag-reference-model';
 
 @Injectable()
 export class SceneService {
@@ -181,6 +182,22 @@ export class SceneService {
 
     this.initialSceneId = game.initialSceneId;
     this.scenes = game.scenes;
+
+    this.scenes.map(scene => {
+      if (!scene.links) {
+        scene.links = new Array<LinkModel>();
+      } else {
+        scene.links.map(link => {
+          if (!link.flagReferences) {
+            link.flagReferences = new Array<FlagReferenceModel>();
+          }
+        });
+      }
+
+      if (!scene.flags) {
+        scene.flags = new Array<FlagModel>();
+      }
+    });
   }
 
   // https://stackoverflow.com/questions/30106476/using-javascripts-atob-to-decode-base64-doesnt-properly-decode-utf-8-strings/30106551

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -24,6 +24,7 @@
   <li>Once a Game has been imported, it will begin immediately.</li>
   <li>For each Scene, you will see the description of the Scene, and the Links to other Scenes that make up your choices for
     how to proceed.</li>
+  <li>If a Link has any Flags attached to it, it will only be visible if all of those Flags are set. A Flag is set when the Scene that that Flag is attached to is visited. Flags are not visible to the user in the Runner, and are only used to show and hide Links based on having visited previous Scenes.</li>
   <li>When you make it to a Scene that does not Link to any other Scene, you've reached an ending of the Game! You'll be able
     to play the Game again, or import a new Game.</li>
 </ul>

--- a/src/app/runner/game-runner/game-runner.component.html
+++ b/src/app/runner/game-runner/game-runner.component.html
@@ -5,7 +5,7 @@
     <span
       *ngIf="currentScene.links.length > 0">
       <button
-        *ngFor="let link of currentScene.links"
+        *ngFor="let link of visibleLinks()"
         class="next-scene-button"
         mat-raised-button
         (click)="loadNextScene(link.toSceneId)">
@@ -14,7 +14,7 @@
     </span>
     <button
       id="play-again-button"
-      *ngIf="currentScene.links.length === 0"
+      *ngIf="visibleLinks().length === 0"
       mat-raised-button color="accent"
       (click)="restartGame()">
       Play Again

--- a/src/app/runner/game-runner/game-runner.component.spec.ts
+++ b/src/app/runner/game-runner/game-runner.component.spec.ts
@@ -103,6 +103,8 @@ describe('GameRunnerComponent', () => {
       return new SceneModel(1, 'Test', 'Test', '', new Array<LinkModel>(), new Array<FlagModel>());
     };
 
+    fakeSceneService.allFlagsSetForLink = () => true;
+
     fixture.detectChanges();
 
     // Must re-query for the playAgainButton because it didn't exist by default.
@@ -122,12 +124,34 @@ describe('GameRunnerComponent', () => {
       new Array<FlagModel>());
     };
 
+    fakeSceneService.allFlagsSetForLink = () => true;
+
     fixture.detectChanges();
 
     nextSceneButtons = fixture.debugElement.queryAll(By.css('.next-scene-button'));
 
     expect(nextSceneButtons.length).toBe(1);
     expect(nextSceneButtons[0].nativeElement.innerText).toBe('Display');
+  });
+
+  it('should hide any next scene buttons where the link does not have all flags set', () => {
+    fakeSceneService.getCurrentScene = () => {
+      return new SceneModel(
+        1,
+        'Test',
+        'Test',
+        '',
+        [ new LinkModel(1, 2, 'Display', [ new FlagReferenceModel(1, 1)]) ],
+      new Array<FlagModel>());
+    };
+
+    fakeSceneService.allFlagsSetForLink = () => false;
+
+    fixture.detectChanges();
+
+    nextSceneButtons = fixture.debugElement.queryAll(By.css('.next-scene-button'));
+
+    expect(nextSceneButtons.length).toBe(0);
   });
 
   it('should load the next scene if the next scene button is clicked', () => {
@@ -138,6 +162,8 @@ describe('GameRunnerComponent', () => {
     fakeSceneService.startGame = tempSceneService.startGame;
     fakeSceneService.getCurrentScene = tempSceneService.getCurrentScene;
     fakeSceneService.loadNextScene = tempSceneService.loadNextScene;
+    fakeSceneService.allFlagsSetForLink = tempSceneService.allFlagsSetForLink;
+    fakeSceneService['toggleFlagsForScene'] = tempSceneService['toggleFlagsForScene'];
 
     fakeSceneService['initialSceneId'] = 5;
     fakeSceneService['scenes'] = [
@@ -190,6 +216,8 @@ describe('GameRunnerComponent', () => {
     fakeSceneService.startGame = tempSceneService.startGame;
     fakeSceneService.getCurrentScene = tempSceneService.getCurrentScene;
     fakeSceneService.loadNextScene = tempSceneService.loadNextScene;
+    fakeSceneService.allFlagsSetForLink = tempSceneService.allFlagsSetForLink;
+    fakeSceneService['toggleFlagsForScene'] = tempSceneService['toggleFlagsForScene'];
 
     fakeSceneService['initialSceneId'] = 5;
     fakeSceneService['scenes'] = [

--- a/src/app/runner/game-runner/game-runner.component.ts
+++ b/src/app/runner/game-runner/game-runner.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit } from '@angular/core';
 import { SceneService } from '../scene/scene.service';
 
 import { SceneModel } from '../../shared/models/scene-model';
+import { LinkModel } from '../../shared/models/link-model';
 
 @Component({
   selector: 'seeya-game-runner',
@@ -18,10 +19,21 @@ export class GameRunnerComponent implements OnInit {
 
   loadNextScene(toSceneId: number): void {
     this.sceneService.loadNextScene(toSceneId);
+    this.sceneService.setFlagsForScene(toSceneId);
   }
 
   restartGame(): void {
     this.sceneService.startGame();
+  }
+
+  visibleLinks(): LinkModel[] {
+    return this.currentScene.links.filter(link => {
+      return this.linkIsVisible(link);
+    });
+  }
+
+  linkIsVisible(link: LinkModel): boolean {
+    return this.sceneService.allFlagsSetForLink(link);
   }
 
   get currentScene(): SceneModel {

--- a/src/app/runner/scene/scene.service.spec.ts
+++ b/src/app/runner/scene/scene.service.spec.ts
@@ -53,7 +53,7 @@ describe('SceneService', () => {
   it('should return current scene after game is started',
     inject([SceneService], (service: SceneService) => {
       /* tslint:disable:max-line-length */
-      service.importGame('eyJpbml0aWFsU2NlbmVJZCI6NSwic2NlbmVzIjpbeyJpZCI6NSwiaGVhZGVyIjoiSGVhZGVyIiwiZGVzY3JpcHRpb24iOiJEZXNjcmlwdGlvbiIsImxpbmsiOnsiZnJvbVNjZW5lSWQiOjUsInRvU2NlbmVJZCI6Nn19LHsiaWQiOjYsImhlYWRlciI6IkhlYWRlcjIiLCJkZXNjcmlwdGlvbiI6IkRlc2NyaXB0aW9uMiIsImxpbmsiOm51bGx9XX0');
+      service.importGame('eyJpbml0aWFsU2NlbmVJZCI6MSwic2NlbmVzIjpbeyJpZCI6MSwiaGVhZGVyIjoiQSBEYXJrIEhhbGx3YXkiLCJkZXNjcmlwdGlvbiI6IllvdSBzdGFuZCBpbiBhIGRpbWx5LWxpdCBoYWxsd2F5IHdpdGggdGhyZWUgZG9vcnMgaW4gZnJvbnQgb2YgeW91LlxuXG5UaGUgZG9vciBvbiB0aGUgbGVmdCBpcyBncmVlbiwgYW5kIGFwcGVhcnMgdG8gYmUgdW5sb2NrZWQuXG5cblRoZSBkb29yIGluIHRoZSBtaWRkbGUgaXMgYmx1ZSwgYW5kIGFsc28gYXBwZWFycyB0byBiZSB1bmxvY2tlZC5cblxuVGhlIGRvb3Igb24gdGhlIHJpZ2h0IGlzIHJlZCwgYW5kIGhhcyBhIGdyZWVuIHBhZGxvY2sgYW5kIGEgYmx1ZSBwYWRsb2NrIG9uIGl0LiIsImltYWdlVXJsIjoiIiwibGlua3MiOlt7ImZyb21TY2VuZUlkIjoxLCJ0b1NjZW5lSWQiOjIsImRpc3BsYXlUZXh0IjoiT3BlbiB0aGUgR3JlZW4gRG9vciIsImZsYWdSZWZlcmVuY2VzIjpbXX0seyJmcm9tU2NlbmVJZCI6MSwidG9TY2VuZUlkIjozLCJkaXNwbGF5VGV4dCI6Ik9wZW4gdGhlIEJsdWUgRG9vciIsImZsYWdSZWZlcmVuY2VzIjpbXX0seyJmcm9tU2NlbmVJZCI6MSwidG9TY2VuZUlkIjo0LCJkaXNwbGF5VGV4dCI6Ik9wZW4gdGhlIFJlZCBEb29yIiwiZmxhZ1JlZmVyZW5jZXMiOlt7ImlkIjowLCJzY2VuZUlkIjoyfSx7ImlkIjoxLCJzY2VuZUlkIjozfV19XSwiZmxhZ3MiOltdfSx7ImlkIjoyLCJoZWFkZXIiOiJBIEdyZWVuIFJvb20iLCJkZXNjcmlwdGlvbiI6Ik9uIGEgc21hbGwgcGVkZXN0YWwgaW4gdGhlIG1pZGRsZSBvZiB0aGUgcm9vbSBpcyBhIGdyZWVuIGtleS5cblxuWW91IHRha2UgdGhlIGtleS4iLCJpbWFnZVVybCI6IiIsImxpbmtzIjpbeyJmcm9tU2NlbmVJZCI6MiwidG9TY2VuZUlkIjoxLCJkaXNwbGF5VGV4dCI6IlJldHVybiB0byB0aGUgSGFsbHdheSIsImZsYWdSZWZlcmVuY2VzIjpbXX1dLCJmbGFncyI6W3siaWQiOjAsInNjZW5lSWQiOjIsIm5hbWUiOiJGbGFnIDEiLCJpc1NldCI6ZmFsc2V9XX0seyJpZCI6MywiaGVhZGVyIjoiQSBCbHVlIFJvb20iLCJkZXNjcmlwdGlvbiI6Ik9uIGEgc21hbGwgcGVkZXN0YWwgaW4gdGhlIG1pZGRsZSBvZiB0aGUgcm9vbSBpcyBhIGJsdWUga2V5LlxuXG5Zb3UgdGFrZSB0aGUga2V5LiIsImltYWdlVXJsIjoiIiwibGlua3MiOlt7ImZyb21TY2VuZUlkIjozLCJ0b1NjZW5lSWQiOjEsImRpc3BsYXlUZXh0IjoiUmV0dXJuIHRvIHRoZSBIYWxsd2F5IiwiZmxhZ1JlZmVyZW5jZXMiOltdfV0sImZsYWdzIjpbeyJpZCI6MSwic2NlbmVJZCI6MywibmFtZSI6IkZsYWcgMiIsImlzU2V0IjpmYWxzZX1dfSx7ImlkIjo0LCJoZWFkZXIiOiJBIFJlZCBSb29tIiwiZGVzY3JpcHRpb24iOiJBIHNpZ24gaW4gdGhlIG1pZGRsZSBvZiB0aGUgcm9vbSBzYXlzIFwiWW91IHdpbiFcIiIsImltYWdlVXJsIjoiIiwibGlua3MiOltdLCJmbGFncyI6W119XX0=');
       /* tslint:enable:max-line-length */
 
       service.startGame();
@@ -65,29 +65,130 @@ describe('SceneService', () => {
     inject([SceneService], (service: SceneService) => {
       // This game string has two scenes.
       /* tslint:disable:max-line-length */
-      service.importGame('eyJpbml0aWFsU2NlbmVJZCI6NSwic2NlbmVzIjpbeyJpZCI6NSwiaGVhZGVyIjoiSGVhZGVyIiwiZGVzY3JpcHRpb24iOiJEZXNjcmlwdGlvbiIsImxpbmsiOnsiZnJvbVNjZW5lSWQiOjUsInRvU2NlbmVJZCI6Nn19LHsiaWQiOjYsImhlYWRlciI6IkhlYWRlcjIiLCJkZXNjcmlwdGlvbiI6IkRlc2NyaXB0aW9uMiIsImxpbmsiOm51bGx9XX0');
+      service.importGame('eyJpbml0aWFsU2NlbmVJZCI6MSwic2NlbmVzIjpbeyJpZCI6MSwiaGVhZGVyIjoiQSBEYXJrIEhhbGx3YXkiLCJkZXNjcmlwdGlvbiI6IllvdSBzdGFuZCBpbiBhIGRpbWx5LWxpdCBoYWxsd2F5IHdpdGggdGhyZWUgZG9vcnMgaW4gZnJvbnQgb2YgeW91LlxuXG5UaGUgZG9vciBvbiB0aGUgbGVmdCBpcyBncmVlbiwgYW5kIGFwcGVhcnMgdG8gYmUgdW5sb2NrZWQuXG5cblRoZSBkb29yIGluIHRoZSBtaWRkbGUgaXMgYmx1ZSwgYW5kIGFsc28gYXBwZWFycyB0byBiZSB1bmxvY2tlZC5cblxuVGhlIGRvb3Igb24gdGhlIHJpZ2h0IGlzIHJlZCwgYW5kIGhhcyBhIGdyZWVuIHBhZGxvY2sgYW5kIGEgYmx1ZSBwYWRsb2NrIG9uIGl0LiIsImltYWdlVXJsIjoiIiwibGlua3MiOlt7ImZyb21TY2VuZUlkIjoxLCJ0b1NjZW5lSWQiOjIsImRpc3BsYXlUZXh0IjoiT3BlbiB0aGUgR3JlZW4gRG9vciIsImZsYWdSZWZlcmVuY2VzIjpbXX0seyJmcm9tU2NlbmVJZCI6MSwidG9TY2VuZUlkIjozLCJkaXNwbGF5VGV4dCI6Ik9wZW4gdGhlIEJsdWUgRG9vciIsImZsYWdSZWZlcmVuY2VzIjpbXX0seyJmcm9tU2NlbmVJZCI6MSwidG9TY2VuZUlkIjo0LCJkaXNwbGF5VGV4dCI6Ik9wZW4gdGhlIFJlZCBEb29yIiwiZmxhZ1JlZmVyZW5jZXMiOlt7ImlkIjowLCJzY2VuZUlkIjoyfSx7ImlkIjoxLCJzY2VuZUlkIjozfV19XSwiZmxhZ3MiOltdfSx7ImlkIjoyLCJoZWFkZXIiOiJBIEdyZWVuIFJvb20iLCJkZXNjcmlwdGlvbiI6Ik9uIGEgc21hbGwgcGVkZXN0YWwgaW4gdGhlIG1pZGRsZSBvZiB0aGUgcm9vbSBpcyBhIGdyZWVuIGtleS5cblxuWW91IHRha2UgdGhlIGtleS4iLCJpbWFnZVVybCI6IiIsImxpbmtzIjpbeyJmcm9tU2NlbmVJZCI6MiwidG9TY2VuZUlkIjoxLCJkaXNwbGF5VGV4dCI6IlJldHVybiB0byB0aGUgSGFsbHdheSIsImZsYWdSZWZlcmVuY2VzIjpbXX1dLCJmbGFncyI6W3siaWQiOjAsInNjZW5lSWQiOjIsIm5hbWUiOiJGbGFnIDEiLCJpc1NldCI6ZmFsc2V9XX0seyJpZCI6MywiaGVhZGVyIjoiQSBCbHVlIFJvb20iLCJkZXNjcmlwdGlvbiI6Ik9uIGEgc21hbGwgcGVkZXN0YWwgaW4gdGhlIG1pZGRsZSBvZiB0aGUgcm9vbSBpcyBhIGJsdWUga2V5LlxuXG5Zb3UgdGFrZSB0aGUga2V5LiIsImltYWdlVXJsIjoiIiwibGlua3MiOlt7ImZyb21TY2VuZUlkIjozLCJ0b1NjZW5lSWQiOjEsImRpc3BsYXlUZXh0IjoiUmV0dXJuIHRvIHRoZSBIYWxsd2F5IiwiZmxhZ1JlZmVyZW5jZXMiOltdfV0sImZsYWdzIjpbeyJpZCI6MSwic2NlbmVJZCI6MywibmFtZSI6IkZsYWcgMiIsImlzU2V0IjpmYWxzZX1dfSx7ImlkIjo0LCJoZWFkZXIiOiJBIFJlZCBSb29tIiwiZGVzY3JpcHRpb24iOiJBIHNpZ24gaW4gdGhlIG1pZGRsZSBvZiB0aGUgcm9vbSBzYXlzIFwiWW91IHdpbiFcIiIsImltYWdlVXJsIjoiIiwibGlua3MiOltdLCJmbGFncyI6W119XX0=');
       /* tslint:enable:max-line-length */
 
       service.startGame();
 
-      expect(service.getNumberOfScenes()).toBe(2);
+      expect(service.getNumberOfScenes()).toBe(4);
     }));
 
   it('should return correct scene after load next scene is called',
     inject([SceneService], (service: SceneService) => {
       // This game string has two scenes.
       /* tslint:disable:max-line-length */
-      service.importGame('eyJpbml0aWFsU2NlbmVJZCI6NSwic2NlbmVzIjpbeyJpZCI6NSwiaGVhZGVyIjoiSGVhZGVyIiwiZGVzY3JpcHRpb24iOiJEZXNjcmlwdGlvbiIsImxpbmsiOnsiZnJvbVNjZW5lSWQiOjUsInRvU2NlbmVJZCI6Nn19LHsiaWQiOjYsImhlYWRlciI6IkhlYWRlcjIiLCJkZXNjcmlwdGlvbiI6IkRlc2NyaXB0aW9uMiIsImxpbmsiOm51bGx9XX0');
+      service.importGame('eyJpbml0aWFsU2NlbmVJZCI6MSwic2NlbmVzIjpbeyJpZCI6MSwiaGVhZGVyIjoiQSBEYXJrIEhhbGx3YXkiLCJkZXNjcmlwdGlvbiI6IllvdSBzdGFuZCBpbiBhIGRpbWx5LWxpdCBoYWxsd2F5IHdpdGggdGhyZWUgZG9vcnMgaW4gZnJvbnQgb2YgeW91LlxuXG5UaGUgZG9vciBvbiB0aGUgbGVmdCBpcyBncmVlbiwgYW5kIGFwcGVhcnMgdG8gYmUgdW5sb2NrZWQuXG5cblRoZSBkb29yIGluIHRoZSBtaWRkbGUgaXMgYmx1ZSwgYW5kIGFsc28gYXBwZWFycyB0byBiZSB1bmxvY2tlZC5cblxuVGhlIGRvb3Igb24gdGhlIHJpZ2h0IGlzIHJlZCwgYW5kIGhhcyBhIGdyZWVuIHBhZGxvY2sgYW5kIGEgYmx1ZSBwYWRsb2NrIG9uIGl0LiIsImltYWdlVXJsIjoiIiwibGlua3MiOlt7ImZyb21TY2VuZUlkIjoxLCJ0b1NjZW5lSWQiOjIsImRpc3BsYXlUZXh0IjoiT3BlbiB0aGUgR3JlZW4gRG9vciIsImZsYWdSZWZlcmVuY2VzIjpbXX0seyJmcm9tU2NlbmVJZCI6MSwidG9TY2VuZUlkIjozLCJkaXNwbGF5VGV4dCI6Ik9wZW4gdGhlIEJsdWUgRG9vciIsImZsYWdSZWZlcmVuY2VzIjpbXX0seyJmcm9tU2NlbmVJZCI6MSwidG9TY2VuZUlkIjo0LCJkaXNwbGF5VGV4dCI6Ik9wZW4gdGhlIFJlZCBEb29yIiwiZmxhZ1JlZmVyZW5jZXMiOlt7ImlkIjowLCJzY2VuZUlkIjoyfSx7ImlkIjoxLCJzY2VuZUlkIjozfV19XSwiZmxhZ3MiOltdfSx7ImlkIjoyLCJoZWFkZXIiOiJBIEdyZWVuIFJvb20iLCJkZXNjcmlwdGlvbiI6Ik9uIGEgc21hbGwgcGVkZXN0YWwgaW4gdGhlIG1pZGRsZSBvZiB0aGUgcm9vbSBpcyBhIGdyZWVuIGtleS5cblxuWW91IHRha2UgdGhlIGtleS4iLCJpbWFnZVVybCI6IiIsImxpbmtzIjpbeyJmcm9tU2NlbmVJZCI6MiwidG9TY2VuZUlkIjoxLCJkaXNwbGF5VGV4dCI6IlJldHVybiB0byB0aGUgSGFsbHdheSIsImZsYWdSZWZlcmVuY2VzIjpbXX1dLCJmbGFncyI6W3siaWQiOjAsInNjZW5lSWQiOjIsIm5hbWUiOiJGbGFnIDEiLCJpc1NldCI6ZmFsc2V9XX0seyJpZCI6MywiaGVhZGVyIjoiQSBCbHVlIFJvb20iLCJkZXNjcmlwdGlvbiI6Ik9uIGEgc21hbGwgcGVkZXN0YWwgaW4gdGhlIG1pZGRsZSBvZiB0aGUgcm9vbSBpcyBhIGJsdWUga2V5LlxuXG5Zb3UgdGFrZSB0aGUga2V5LiIsImltYWdlVXJsIjoiIiwibGlua3MiOlt7ImZyb21TY2VuZUlkIjozLCJ0b1NjZW5lSWQiOjEsImRpc3BsYXlUZXh0IjoiUmV0dXJuIHRvIHRoZSBIYWxsd2F5IiwiZmxhZ1JlZmVyZW5jZXMiOltdfV0sImZsYWdzIjpbeyJpZCI6MSwic2NlbmVJZCI6MywibmFtZSI6IkZsYWcgMiIsImlzU2V0IjpmYWxzZX1dfSx7ImlkIjo0LCJoZWFkZXIiOiJBIFJlZCBSb29tIiwiZGVzY3JpcHRpb24iOiJBIHNpZ24gaW4gdGhlIG1pZGRsZSBvZiB0aGUgcm9vbSBzYXlzIFwiWW91IHdpbiFcIiIsImltYWdlVXJsIjoiIiwibGlua3MiOltdLCJmbGFncyI6W119XX0=');
       /* tslint:enable:max-line-length */
 
       service.startGame();
 
-      service.loadNextScene(6);
+      service.loadNextScene(2);
 
       const nextScene = service.getCurrentScene();
 
       expect(nextScene).toBeTruthy();
-      expect(nextScene.id).toBe(6);
+      expect(nextScene.id).toBe(2);
+    }));
+
+  it('should set all flags on the specified scene',
+    inject([SceneService], (service: SceneService) => {
+      service['scenes'] = [
+        new SceneModel(
+          1,
+          'Test',
+          'Test',
+          null,
+          new Array<LinkModel>(),
+          [
+            new FlagModel(1, 1, 'Test', false),
+            new FlagModel(2, 1, 'Test', false)
+          ]
+        )
+      ];
+
+      service.setFlagsForScene(1);
+
+      service['scenes'][0].flags.map(flag => {
+        expect(flag.isSet).toBeTruthy();
+      });
+    }));
+
+  it('should return true when all flags for a link are set',
+    inject([SceneService], (service: SceneService) => {
+      service['scenes'] = [
+        new SceneModel(
+          1,
+          'Test',
+          'Test',
+          null,
+          new Array<LinkModel>(),
+          [
+            new FlagModel(1, 1, 'Test', true),
+            new FlagModel(2, 1, 'Test', true)
+          ]
+        ),
+        new SceneModel(
+          2,
+          'Test',
+          'Test',
+          null,
+          [
+            new LinkModel(2, 1, 'Test', [
+              new FlagReferenceModel(1, 1),
+              new FlagReferenceModel(2, 1)
+            ])
+          ],
+          [
+            new FlagModel(1, 1, 'Test', false),
+            new FlagModel(2, 1, 'Test', false)
+          ]
+        )
+      ];
+
+      expect(service.allFlagsSetForLink(
+        new LinkModel(2, 1, 'Test', [
+          new FlagReferenceModel(1, 1),
+          new FlagReferenceModel(2, 1)
+        ]))).toBeTruthy();
+    }));
+
+  it('should return false if any flags for the link are not set',
+    inject([SceneService], (service: SceneService) => {
+      service['scenes'] = [
+        new SceneModel(
+          1,
+          'Test',
+          'Test',
+          null,
+          new Array<LinkModel>(),
+          [
+            new FlagModel(1, 1, 'Test', true),
+            new FlagModel(2, 1, 'Test', false)
+          ]
+        ),
+        new SceneModel(
+          2,
+          'Test',
+          'Test',
+          null,
+          [
+            new LinkModel(2, 1, 'Test', [
+              new FlagReferenceModel(1, 1),
+              new FlagReferenceModel(2, 1)
+            ])
+          ],
+          [
+            new FlagModel(1, 1, 'Test', false),
+            new FlagModel(2, 1, 'Test', false)
+          ]
+        )
+      ];
+
+      expect(service.allFlagsSetForLink(
+        new LinkModel(2, 1, 'Test', [
+          new FlagReferenceModel(1, 1),
+          new FlagReferenceModel(2, 1)
+        ]))).toBeFalsy();
     }));
 
   it('should not have the game finished if there is no current scene',

--- a/src/app/runner/scene/scene.service.ts
+++ b/src/app/runner/scene/scene.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { SceneModel } from '../../shared/models/scene-model';
 import { GameModel } from '../../shared/models/game-model';
+import { LinkModel } from '../../shared/models/link-model';
+import { FlagModel } from '../../shared/models/flag-model';
+import { FlagReferenceModel } from '../../shared/models/flag-reference-model';
 
 @Injectable()
 export class SceneService {
@@ -23,10 +26,33 @@ export class SceneService {
 
     this.initialSceneId = game.initialSceneId;
     this.scenes = game.scenes;
+
+    this.scenes.map(scene => {
+      if (!scene.links) {
+        scene.links = new Array<LinkModel>();
+      } else {
+        scene.links.map(link => {
+          if (!link.flagReferences) {
+            link.flagReferences = new Array<FlagReferenceModel>();
+          }
+        });
+      }
+
+      if (!scene.flags) {
+        scene.flags = new Array<FlagModel>();
+      }
+    });
   }
 
   startGame(): void {
     if (this.scenes.length > 0) {
+      this.scenes.map(scene => {
+        this.toggleFlagsForScene(
+          scene.id,
+          false
+        );
+      });
+
       this.currentScene =
         this.scenes.filter(scene => scene.id === this.initialSceneId)[0];
     }
@@ -47,6 +73,41 @@ export class SceneService {
     }
   }
 
+  setFlagsForScene(sceneId: number): void {
+    this.toggleFlagsForScene(
+      sceneId,
+      true
+    );
+  }
+
+  allFlagsSetForLink(link: LinkModel): boolean {
+    let allFlagsSet = true;
+
+    link.flagReferences.map(flagReference => {
+      const flagScene: SceneModel = this.scenes.filter(scene => {
+        return scene.id === flagReference.sceneId;
+      })[0];
+
+      if (flagScene) {
+        const linkFlag: FlagModel = flagScene.flags.filter(flag => {
+          return flag.id === flagReference.id;
+        })[0];
+
+        if (linkFlag) {
+          if (!linkFlag.isSet) {
+            allFlagsSet = false;
+          }
+        } else {
+          allFlagsSet = false;
+        }
+      } else {
+        allFlagsSet = false;
+      }
+    });
+
+    return allFlagsSet;
+  }
+
   gameIsFinished(): boolean {
     return this.currentScene !== null && this.currentScene.links.length === 0;
   }
@@ -56,5 +117,25 @@ export class SceneService {
     return decodeURIComponent(Array.prototype.map.call(atob(str), (c) => {
       return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
     }).join(''));
+  }
+
+  private toggleFlagsForScene(
+    sceneId: number,
+    value: boolean): void {
+    if (this.scenes.length > 0) {
+      const sceneToUpdate = this.scenes.filter(scene => {
+        return scene.id === sceneId;
+      })[0];
+
+      if (sceneToUpdate) {
+        const sceneIndexToUpdate = this.scenes.indexOf(sceneToUpdate);
+
+        sceneToUpdate.flags.map(flag => {
+          flag.isSet = value;
+        });
+
+        this.scenes[sceneIndexToUpdate] = sceneToUpdate;
+      }
+    }
   }
 }

--- a/src/app/shared/factories/flag-reference-factory.ts
+++ b/src/app/shared/factories/flag-reference-factory.ts
@@ -2,7 +2,7 @@ import { FlagReferenceModel } from '../models/flag-reference-model';
 
 export class FlagReferenceFactory {
     /**
-     * Creates a new FlagModel object.
+     * Creates a new FlagReferenceModel object.
      */
     createFlagReference(
         id: number,

--- a/src/app/shared/factories/link-factory.ts
+++ b/src/app/shared/factories/link-factory.ts
@@ -39,9 +39,10 @@ export class LinkFactory {
 
       if (flags !== null &&
           flags !== undefined) {
-        const frf = new FlagReferenceFactory();
 
         flags.map(flag => {
+          const frf = new FlagReferenceFactory();
+
           flagReferences.push(frf.createFlagReference(
             flag.id,
             flag.sceneId


### PR DESCRIPTION
First version of Flags now works in both Generator and Runner.

Allows for hiding of Links if necessary prior Scenes have not been visited.